### PR TITLE
feat/library: creating Ansible's official lib dir for roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,10 @@ An Ansible Module for creating or deleting Spotinst Elastigroups
 - [spotinst-sdk-python](https://github.com/spotinst/spotinst-sdk-python) >= `v2.0.0`
 
 ## Installation
+
+### module directory
 If you'd like to work with this version of the module and not the supplied version that is packaged with Ansible,
-you can copy the module into your Ansible module directory. 
+you can copy the module into your Ansible module directory.
 
 Example, assuming your Ansible module directory is at - '~/.ansible':
 ```bash
@@ -46,6 +48,21 @@ mkdir -p ~/.ansible/plugins/modules/cloud/
 cp -r spotinst-ansible-module/spotinst/ ~/.ansible/plugins/modules/cloud/
 ```
 Otherwise the module comes pre-installed with the latest [Ansible](https://github.com/ansible/ansible) release.
+
+### role directory
+
+You also can use this project as an Ansible role to be available in your playbook though `library/` directory. See how you can create as an [role](https://docs.ansible.com/ansible/latest/dev_guide/developing_locally.html#adding-a-module-locally):
+1. Clone the project, or create an git module, into your roles directory (see `roles_path=` on `ansible.cfg`):
+ 1. clone in roles path `./roles`:
+```bash
+git clone https://github.com/spotinst/spotinst-ansible-module roles/spotinst-ansible-module
+```
+ 1. use as git module:
+```bash
+git submodule add git@github.com:spotinst/spotinst-ansible-module.git roles/spotinst-ansible-module
+```
+1. Use the module in your playbook. See `role` section on [playbook spotinst-event-subscription-role.yml](./examples/events/spotinst-event-subscription-role.yml)
+
 
 ## Configuring Credentials
 The mechanism in which the module looks for credentials is to search through a list of possible locations and stop as soon as it finds credentials. 

--- a/examples/events/spotinst-event-subscription-role.yml
+++ b/examples/events/spotinst-event-subscription-role.yml
@@ -1,0 +1,20 @@
+#In this basic example, we create an event subscription
+
+- hosts: localhost
+  tasks:
+    - name: create ocean
+      spotinst_event_subscription:
+        account_id: 
+        token: 
+        state: present
+        id: sis-e62dfd0f
+        resource_id: sig-992a78db
+        protocol: web
+        endpoint: https://webhook.com
+        event_type: GROUP_UPDATED
+        event_format: { "subject" : "%s", "message" : "%s" }
+      register: result
+    - debug: var=result
+  
+  roles:
+    - spotinst-ansible-modules

--- a/library
+++ b/library
@@ -1,0 +1,1 @@
+spotinst/


### PR DESCRIPTION
According with Ansible documentations, is an best practice to create custom libraries inside `library`directory in it's directories structures, I.E ansible root or role dirs.

Following this way, we can use this project as an official directory importing automatically these modules to the role dir.

For more information, please read the README section [updated here](https://github.com/spotinst/spotinst-ansible-module/pull/9/files#diff-04c6e90faac2675aa89e2176d2eec7d8R52)

Changes:
- creating symlink from `spotinst/` (modules dir) to `library`, official Ansible anternative for modules lookup.